### PR TITLE
Check all module files

### DIFF
--- a/pos_to_hotel_folio/__manifest__.py
+++ b/pos_to_hotel_folio/__manifest__.py
@@ -14,6 +14,7 @@
     'assets': {
         'point_of_sale._assets_pos': [
             'pos_to_hotel_folio/static/src/js/pos_hotel_folio.js',
+            'pos_to_hotel_folio/static/src/xml/pos_hotel_folio.xml',
         ],
     },
     'installable': True,

--- a/pos_to_hotel_folio/models/pos_order.py
+++ b/pos_to_hotel_folio/models/pos_order.py
@@ -40,7 +40,8 @@ class PosOrder(models.Model):
             ('booking_id.state', 'in', ['draft', 'check_in'])
         ])
         rooms = active_lines.mapped('room_id')
-        return [{'id': room.id, 'name': room.name_get()[0][1]} for room in rooms] if rooms else []
+        # Use display_name to avoid issues if name_get is overridden/missing
+        return [{'id': room.id, 'name': room.display_name} for room in rooms] if rooms else []
 
     def _get_active_booking_for_room(self, room):
         self.ensure_one()

--- a/pos_to_hotel_folio/static/src/js/pos_hotel_folio.js
+++ b/pos_to_hotel_folio/static/src/js/pos_hotel_folio.js
@@ -19,6 +19,14 @@ patch(PosStore.prototype, {
         }
         return res;
     },
+    async pay() {
+        // Intercept the default payment flow in restaurant mode
+        if (this.config?.module_pos_restaurant) {
+            await this.sendCurrentOrderToFolio();
+            return;
+        }
+        return await super.pay(...arguments);
+    },
     async sendCurrentOrderToFolio() {
         const order = this.get_order();
         if (!order || order.lines.length === 0 || order.finalized) {

--- a/pos_to_hotel_folio/static/src/js/pos_hotel_folio.js
+++ b/pos_to_hotel_folio/static/src/js/pos_hotel_folio.js
@@ -1,125 +1,68 @@
 /** @odoo-module */
 
-import { PosStore } from '@point_of_sale/app/store/pos_store';
-import { Order } from '@point_of_sale/models/order';
-import { ProductScreen } from '@point_of_sale/app/screens/product_screen/product_screen';
-import { SelectionPopup } from '@point_of_sale/app/utils/selection_popup/selection_popup';
-import { ErrorPopup } from '@point_of_sale/app/utils/error_popup/error_popup';
-import { ConfirmPopup } from '@point_of_sale/app/utils/confirm_popup/confirm_popup';
 import { patch } from '@web/core/utils/patch';
 import { useService } from '@web/core/utils/hooks';
+import { PosStore } from '@point_of_sale/app/store/pos_store';
+import { ActionpadWidget } from '@point_of_sale/app/screens/product_screen/action_pad/action_pad';
+import { SelectionPopup } from '@point_of_sale/app/utils/input_popups/selection_popup';
+import { makeAwaitable } from '@point_of_sale/app/store/make_awaitable_dialog';
 
-// Debug to confirm JS and module loading
-console.log('POS Hotel Folio JS Loaded');
-console.log('Imported modules:', {
-    PosStore: PosStore ? 'Loaded' : 'Undefined',
-    Order: Order ? 'Loaded' : 'Undefined',
-    ProductScreen: ProductScreen ? 'Loaded' : 'Undefined',
-    SelectionPopup: SelectionPopup ? 'Loaded' : 'Undefined',
-    ErrorPopup: ErrorPopup ? 'Loaded' : 'Undefined',
-    ConfirmPopup: ConfirmPopup ? 'Loaded' : 'Undefined'
-});
-
-// Extend PosStore to load occupied rooms
+// Load occupied rooms after the POS data is processed
 patch(PosStore.prototype, {
-    async after_load_server_data() {
-        await super.after_load_server_data();
+    async afterProcessServerData() {
+        const res = await super.afterProcessServerData(...arguments);
         try {
-            this.occupied_rooms = await this.orm.call('pos.order', 'get_occupied_rooms', []);
-            console.log('Occupied rooms loaded:', this.occupied_rooms);
+            this.occupied_rooms = await this.data.call('pos.order', 'get_occupied_rooms', []);
         } catch (error) {
-            console.error('Failed to load occupied rooms:', error);
+            console.error('pos_to_hotel_folio: failed to load occupied rooms', error);
+            this.occupied_rooms = [];
         }
-    }
-});
-
-// Extend Order to include room_id and sent_to_folio
-patch(Order.prototype, {
-    setup(values) {
-        super.setup(values);
-        this.room_id = this.room_id || null;
-        this.sent_to_folio = this.sent_to_folio || false;
-        console.log('Order setup:', { room_id: this.room_id, sent_to_folio: this.sent_to_folio });
+        return res;
     },
-    export_as_JSON() {
-        const json = super.export_as_JSON();
-        json.room_id = this.room_id;
-        json.sent_to_folio = this.sent_to_folio;
-        return json;
-    }
-});
-
-// Extend ProductScreen to replace Payment button with Send to Folio
-patch(ProductScreen.prototype, {
-    setup() {
-        super.setup();
-        this.popup = useService('popup');
-        this.orm = useService('orm');
-        console.log('ProductScreen patched');
-    },
-    get payButtonLabel() {
-        const order = this.pos.get_order();
-        return order && order.sent_to_folio ? 'Sent' : 'Send to Folio';
-    },
-    async onClickPay() {
-        const order = this.pos.get_order();
-        console.log('onClickPay called, order:', order);
-        if (!order || order.get_orderlines().length === 0 || order.sent_to_folio) {
-            console.log('Invalid order or already sent:', { orderlines: order?.get_orderlines().length, sent: order?.sent_to_folio });
+    async sendCurrentOrderToFolio() {
+        const order = this.get_order();
+        if (!order || order.lines.length === 0 || order.finalized) {
             return;
         }
-        // Ensure order is sent to kitchen (Restaurant mode)
-        if (this.pos.config.is_restaurant) {
-            try {
-                await this.env.services.rpc({
-                    model: 'pos.order',
-                    method: 'send_to_kitchen',
-                    args: [[order.backendId || order.name]],
-                });
-                console.log('Order sent to kitchen');
-            } catch (error) {
-                console.error('Failed to send to kitchen:', error);
-            }
+        try {
+            await this.syncAllOrders({ orders: [order] });
+        } catch (e) {
+            // ignore
         }
-        const roomList = this.pos.occupied_rooms.map((room) => ({
-            id: room.id,
-            label: room.name,
-            item: room,
-        }));
-        console.log('Room list:', roomList);
-        if (roomList.length === 0) {
-            await this.popup.add(ErrorPopup, {
-                title: 'No Occupied Rooms',
-                body: 'No rooms with active folios available. Please check hotel bookings.',
-            });
-            console.log('No rooms popup shown');
+        const rooms = this.occupied_rooms || [];
+        if (!rooms.length) {
+            this.notification.add('No occupied rooms with active folios', { type: 'warning' });
             return;
         }
-        const { confirmed, payload: selectedRoom } = await this.popup.add(SelectionPopup, {
+        const list = rooms.map((r) => ({ id: r.id, label: r.name, item: r }));
+        const selectedRoom = await makeAwaitable(this.dialog, SelectionPopup, {
             title: 'Select Occupied Room',
-            list: roomList,
+            list,
         });
-        if (confirmed) {
-            order.room_id = selectedRoom.id;
-            console.log('Selected room:', selectedRoom);
-            try {
-                await this.orm.call('pos.order', 'action_send_to_folio', [[order.backendId || order.name]]);
-                order.sent_to_folio = true;
-                await this.popup.add(ConfirmPopup, {
-                    title: 'Success',
-                    body: 'Order sent to folio and added to room invoice.',
-                });
-                console.log('Order sent to folio, new order created');
-                // Finalize: remove order, start new
-                this.pos.removeOrder(order);
-                this.pos.add_new_order();
-            } catch (error) {
-                console.error('Failed to send to folio:', error);
-                await this.popup.add(ErrorPopup, {
-                    title: 'Error',
-                    body: 'Failed to send to folio. Check server logs.',
-                });
-            }
+        if (!selectedRoom) {
+            return;
         }
-    }
+        try {
+            await this.data.write('pos.order', [order.id], { room_id: selectedRoom.id });
+            await this.data.call('pos.order', 'action_send_to_folio', [[order.id]]);
+            this.notification.add('Order sent to room folio', { type: 'success' });
+            this.removeOrder(order);
+            this.add_new_order();
+        } catch (error) {
+            console.error('pos_to_hotel_folio: send to folio failed', error);
+            this.notification.add('Failed to send to folio. Please try again.', { type: 'danger' });
+        }
+    },
+});
+
+// Add a Send-to-Folio action on the Action pad (replaces Payment button via XML)
+patch(ActionpadWidget.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.dialog = useService('dialog');
+        this.notification = useService('notification');
+    },
+    async onClickSendToFolio() {
+        await this.pos.sendCurrentOrderToFolio();
+    },
 });

--- a/pos_to_hotel_folio/static/src/xml/pos_hotel_folio.xml
+++ b/pos_to_hotel_folio/static/src/xml/pos_hotel_folio.xml
@@ -8,4 +8,28 @@
             <attribute name="t-esc">'Send to Folio'</attribute>
         </xpath>
     </t>
+
+    <!-- Also override the restaurant-specific ActionpadWidget to replace its Payment button -->
+    <t t-name="pos_to_hotel_folio.ActionpadWidgetRestaurant" t-inherit="pos_restaurant.ActionpadWidget" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('validation')]//button[hasclass('pay-order-button')]" position="replace">
+            <button
+                t-if="!currentOrder.is_empty()"
+                t-on-click="() =&gt; pos.sendCurrentOrderToFolio()"
+                class="button pay-order-button btn btn-lg w-50"
+                t-attf-class="{{ this.highlightPay ? 'highlight btn-primary' : 'btn-light' }}"
+            >
+                Send to Folio
+            </button>
+        </xpath>
+    </t>
+
+    <!-- Update the mobile bottom pay button on ProductScreen -->
+    <t t-name="pos_to_hotel_folio.ProductScreen" t-inherit="point_of_sale.ProductScreen" t-inherit-mode="extension">
+        <xpath expr="//button[hasclass('pay-button')]" position="attributes">
+            <attribute name="t-on-click">() =&gt; this.pos.sendCurrentOrderToFolio()</attribute>
+        </xpath>
+        <xpath expr="//button[hasclass('pay-button')]/span[1]" position="replace">
+            <span class="d-block">Send to Folio</span>
+        </xpath>
+    </t>
 </templates>

--- a/pos_to_hotel_folio/static/src/xml/pos_hotel_folio.xml
+++ b/pos_to_hotel_folio/static/src/xml/pos_hotel_folio.xml
@@ -1,24 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<templates id="pos_to_hotel_folio_templates">
-    <!-- Extend OrderWidget to add room selector -->
-    <t t-name="pos_to_hotel_folio.OrderWidget" t-extend="point_of_sale.OrderWidget">
-        <t t-jquery=".orderlines" t-operation="after">
-            <div class="pos-room-selector mb-2">
-                <label class="control-label">Room:</label>
-                <select name="room_id" class="form-control">
-                    <option value="">Select Room</option>
-                    <t t-foreach="widget.env.pos.available_rooms" t-as="room">
-                        <option t-att-value="room.id" t-esc="room.name"/>
-                    </t>
-                </select>
-            </div>
-        </t>
-    </t>
-
-    <!-- Template for Send to Folio button -->
-    <t t-name="pos_to_hotel_folio.SendToFolioButton">
-        <button class="btn btn-primary control-button" t-att-disabled="props.isDisabled ? 'disabled' : null">
-            Send to Folio
-        </button>
+<templates id="pos_to_hotel_folio_templates" xml:space="preserve">
+    <!-- Replace Payment button label and action with Send to Folio in ProductScreen action pad -->
+    <t t-name="pos_to_hotel_folio.ActionpadWidget" t-inherit="point_of_sale.ActionpadWidget" t-inherit-mode="extension">
+        <!-- Change the primary action button label and click handler -->
+        <xpath expr="//div[hasclass('validation')]//button[hasclass('pay-order-button')]" position="attributes">
+            <attribute name="t-on-click">() =&gt; pos.sendCurrentOrderToFolio()</attribute>
+            <attribute name="t-esc">'Send to Folio'</attribute>
+        </xpath>
     </t>
 </templates>


### PR DESCRIPTION
Fix POS JS errors and implement "Send to Folio" functionality to integrate restaurant orders with hotel room folios.

The existing `pos_to_hotel_folio` module had Odoo 18 JS import path issues and incorrect API usage, preventing the "Send to Folio" button from appearing and functioning correctly to transfer order lines to hotel room folios. This PR corrects these issues and implements the full end-to-end flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-38b773fc-7152-420b-bbbc-d1354f146fb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-38b773fc-7152-420b-bbbc-d1354f146fb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

